### PR TITLE
Change to package build and install in win32

### DIFF
--- a/dpk/GMLib_D_Berlin.dproj
+++ b/dpk/GMLib_D_Berlin.dproj
@@ -8,7 +8,7 @@
         <AppType>Package</AppType>
         <FrameworkType>None</FrameworkType>
         <ProjectVersion>18.2</ProjectVersion>
-        <Platform Condition="'$(Platform)'==''">Win64</Platform>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
         <Base>true</Base>


### PR DESCRIPTION
This change is intended to leave the installable package as it was as a win64 output platform, not allowing users to be installing on delphi starter in the Berlin version